### PR TITLE
Support default address better

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-spree_branch = '2-2-stable'
+spree_branch = '2-3-stable'
 gem 'spree', github: 'spree/spree', :branch => spree_branch
 gem 'spree_auth_devise', :git => 'git://github.com/spree/spree_auth_devise', :branch => spree_branch
 gem 'coffee-rails', '~> 4.0.0'

--- a/app/assets/stylesheets/spree/frontend/spree_address_book.scss
+++ b/app/assets/stylesheets/spree/frontend/spree_address_book.scss
@@ -17,3 +17,5 @@ div#checkout #checkout_form_address {
 .hidden {
   display: none;
 }
+
+#save_user_address { margin: 0 0.5em 0 2em }

--- a/app/helpers/spree/checkout_helper_decorator.rb
+++ b/app/helpers/spree/checkout_helper_decorator.rb
@@ -1,0 +1,45 @@
+Spree::CheckoutHelper.module_eval do
+
+  def address_is_checked(order, address, address_type)
+    field = address_type == 'shipping' ? :ship_address_id : :bill_address_id
+    selected = order.public_send(field) if order.public_send(field).present?
+    return address.id == selected
+  end
+
+  # Outputs a checkbox to allow a user to indicate if we should save the address
+  # as their default address.
+  def save_default_address_check_box
+    user = try_spree_current_user # To save a few characters
+
+    # The user model doesn't support saving a default address
+    return unless
+      user.respond_to?(:persist_order_address) &&
+      user.respond_to?(:ship_address_id) &&
+      user.respond_to?(:bill_address_id)
+
+    # For clarity
+    has_defaults = user.bill_address_id? && user.ship_address_id?
+
+    # By default don't overwrite their default address
+    should_save = false
+
+    # It should save if they don't already have a default
+    should_save = true unless has_defaults
+
+    # In general the user should be able to modify this input
+    readonly = false
+
+    # If they don't already have a default force them to
+    readonly = true unless has_defaults
+
+    # To work around the fact that readonly doesn't really stop a checkbox
+    # from being enabled/disabled in HTML
+    onclick = 'this.checked=!this.checked' if readonly
+
+    # Build actual UI elements
+    label = label_tag :save_user_address, Spree.t(:save_my_address)
+    input = check_box_tag 'save_user_address', '1', should_save, readonly: readonly, onclick: onclick
+
+    (input + label).html_safe
+  end
+end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -52,6 +52,16 @@ Spree::Order.class_eval do
     self.update_attributes(ship_address_id: address.id) if shipping.present?
   end
 
+  # Override default spree implementation to reference address instead of
+  # copying the address. Also unlike stock spree, we copy the ship address even
+  # if there is no delivery state for completeness.
+  def assign_default_addresses!
+    if self.user
+      self.bill_address_id = user.bill_address_id if !self.bill_address_id && user.bill_address.try(:valid?)
+      self.ship_address_id = user.ship_address_id if !self.ship_address_id && user.ship_address.try(:valid?)
+    end
+  end
+
   private
 
   # Updates an existing address or creates a new one

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -15,7 +15,7 @@ Spree.user_class.class_eval do
 
   # This is the method that Spree calls when the user has requested that the
   # address be their default address. Spree makes a copy from the order. Instead
-  # we just want to
+  # we just want to reference the address so we don't create extra address objects.
   def persist_order_address(order)
     update_attributes bill_address_id: order.bill_address_id
 

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,15 +1,25 @@
 Spree.user_class.class_eval do
-  after_create :link_address
+  after_save :link_address
 
   has_many :addresses, -> { where(:deleted_at => nil).order("updated_at DESC") }, :class_name => 'Spree::Address'
 
   def link_address
-    bill_address.update_attributes(user_id: id) if bill_address
-    ship_address.update_attributes(user_id: id) if ship_address
+    bill_address.update_attributes(user_id: id) if bill_address_id_changed? && bill_address
+    ship_address.update_attributes(user_id: id) if ship_address_id_changed? && ship_address
   end
 
   def save_default_addresses(billing, shipping, address)
     update_attributes(bill_address_id: address.id) if billing.present?
     update_attributes(ship_address_id: address.id) if shipping.present?
+  end
+
+  # This is the method that Spree calls when the user has requested that the
+  # address be their default address. Spree makes a copy from the order. Instead
+  # we just want to
+  def persist_order_address(order)
+    update_attributes bill_address_id: order.bill_address_id
+
+    # May not be present if delivery step has been removed
+    update_attributes ship_address_id: order.ship_address_id if order.ship_address
   end
 end

--- a/app/views/spree/checkout/_address.html.erb
+++ b/app/views/spree/checkout/_address.html.erb
@@ -11,7 +11,7 @@
 
       <% if address_type == 'shipping' && !Spree::AddressBook::Config[:disable_bill_address] %>
         <p class="field checkbox"  data-hook="use_billing">
-          <%= check_box_tag 'order[use_billing]', '1', (!(@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address.same_as?(@order.ship_address)) %>
+          <%= check_box_tag 'order[use_billing]', '1', (!(@order.bill_address.blank? && @order.ship_address.blank?) && @order.bill_address.same_as?(@order.ship_address)) %>
           <%= label_tag :order_use_billing, Spree.t(:use_billing_address), :id => 'use_billing' %>
         </p>
       <% end %>
@@ -21,14 +21,14 @@
           <p class="field">
             <% @addresses.each_with_index do |address, idx| %>
               <span id="<%= [address_type, dom_id(address)].join('_') %>">
-                <label><%= form.radio_button "#{address_name}_id", address.id, :checked => (idx == 0) %> <%= address %></label> <%= link_to Spree.t(:edit), edit_address_path(address) %><br />
+                <label><%= form.radio_button "#{address_name}_id", address.id, :checked => address_is_checked(@order, address, address_type) %> <%= address %></label> <%= link_to Spree.t(:edit), edit_address_path(address) %><br />
               </span>
             <% end %>
             <label><%= form.radio_button "#{address_name}_id", 0 %> <%= I18n.t(:other_address, :scope => :address_book) %></label>
           </p>
         </div>
       <% end %>
-      <%= form.fields_for address_name do |address_form| %>
+      <%= form.fields_for address_name, Spree::Address.default do |address_form| %>
         <div class="inner" data-hook=<%="#{address_type}_inner" %>>
           <%= render :partial => 'spree/addresses/form', :locals => {
             :address_name => address_name,
@@ -45,4 +45,5 @@
 <hr class="clear" />
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag Spree.t(:save_and_continue), :class => 'continue button primary' %>
+  <%= save_default_address_check_box %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,5 @@ en:
     use_current_order: "Use for Current Order"
     use_billing_address: "Use as Billing Address"
     use_shipping_address: "Use as Shipping Address"
+  spree:
+    save_my_address: "Make these addresses my default"

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Spree::CheckoutHelper do
+
+  describe 'address_is_checked' do
+    let(:order) { create :order }
+    let(:address) { order.bill_address }
+    let(:invalid_address) { create :address }
+
+    it 'is checked if matching' do
+      expect( helper.address_is_checked order, address, 'bill_address' ).to be true
+    end
+
+    it 'is not checked if not matching' do
+      expect( helper.address_is_checked order, invalid_address, 'bill_address' ).to be false
+    end
+  end
+
+  describe 'save_default_address_check_box' do
+
+    it 'is ignored if invalid model' do
+      helper.stub(:try_spree_current_user).and_return nil
+      expect( helper.save_default_address_check_box ).to be_nil
+    end
+
+    it 'is checked and read-only if no existing default' do
+      user = create :user
+      expect( user.bill_address ).to be_nil
+      expect( user.ship_address ).to be_nil
+      helper.stub(:try_spree_current_user).and_return user
+      output = helper.save_default_address_check_box
+      expect( output ).to match /checked/
+      expect( output ).to match /readonly/
+    end
+
+    it 'is unchecked and readonly otherwise' do
+      user = create :user_with_addreses
+      expect( user.bill_address ).not_to be_nil
+      expect( user.ship_address ).not_to be_nil
+      helper.stub(:try_spree_current_user).and_return user
+      output = helper.save_default_address_check_box
+      expect( output ).not_to match /checked/
+      expect( output ).not_to match /readonly/
+    end
+
+  end
+
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -24,14 +24,29 @@ describe Spree::Order do
       @order = FactoryGirl.create(:order, :bill_address_id => address.id, :ship_address_id => address.id)
       @order.bill_address_id.should == @order.ship_address_id
     end
-  
+
     it "should have equal ids when option use_billing is active" do
       address = FactoryGirl.create(:address)
       @order  = FactoryGirl.create(:order, :use_billing => true,
-                        :bill_address_id => address.id, 
+                        :bill_address_id => address.id,
                         :ship_address_id => nil)
       @order = @order.reload
       @order.bill_address_id.should == @order.ship_address_id
+    end
+  end
+
+  describe 'default addresses should be references' do
+    let(:user) { create :user_with_addreses }
+    let(:order) { create :order, user: user, bill_address: nil, ship_address: nil }
+
+    it 'should reference address instead of copy' do
+      expect( order.bill_address_id ).to be_nil
+      expect( order.ship_address_id ).to be_nil
+
+      order.assign_default_addresses!
+
+      expect( order.bill_address_id ).to eq user.bill_address_id
+      expect( order.ship_address_id ).to eq user.ship_address_id
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,18 +3,44 @@ require 'spec_helper'
 describe Spree::User do
   let(:user) { FactoryGirl.create(:user) }
   let(:address) { FactoryGirl.create(:address) }
-  let(:address2) { FactoryGirl.create(:address) }
-  before {
-    address.user = user
-    address.save
-    address2.user = user
-    address2.save
-  }
 
   describe 'user has_many addresses' do
+    let(:address2) { FactoryGirl.create(:address) }
+    before {
+      address.user = user
+      address.save
+      address2.user = user
+      address2.save
+    }
+
     it 'should have many addresses' do
       user.should respond_to(:addresses)
       user.addresses.should eq([address2, address])
+    end
+  end
+
+  describe 'address link' do
+    it 'should auto-link addresses' do
+      expect( address.user_id ).to be_nil
+
+      user.bill_address = address
+      user.save!
+
+      expect( address.user_id ).to eq user.id
+    end
+  end
+
+  describe 'default assignment' do
+    let(:order) { create :order_with_line_items, user: user }
+
+    it 'default assignment is reference' do
+      expect( user.ship_address ).to be_nil
+      expect( user.bill_address ).to be_nil
+
+      user.persist_order_address order
+
+      expect( user.ship_address_id ).to eq order.ship_address_id
+      expect( user.bill_address_id ).to eq order.bill_address_id
     end
   end
 

--- a/spree_address_book.gemspec
+++ b/spree_address_book.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 2.14'
   s.add_development_dependency 'shoulda-matchers', '~> 2.5'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'factory_girl', '~> 4.4.0'
+  s.add_development_dependency 'factory_girl', '~> 4.5.0'
   s.add_development_dependency 'database_cleaner', '~> 1.2.0'
   s.add_development_dependency 'sqlite3', '~> 1.3.8'
   s.add_development_dependency 'capybara', '~> 2.2.1'


### PR DESCRIPTION
Commit message contains full details. This is towards the goal of better supporting digital checkout by pulling from the default. Prior to this commit the addon doesn't allow the user to populate a default during checkout.
