### PR TITLE
Updated editable conditions to only account for completed orders

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -14,7 +14,7 @@ Spree::Address.class_eval do
 
   # can modify an address if it's not been used in an completed order
   def editable?
-    new_record? || (shipments.empty? && Spree::Order.complete.where("bill_address_id = ? OR ship_address_id = ?", self.id, self.id).count == 0)
+    new_record? || Spree::Order.complete.where("bill_address_id = ? OR ship_address_id = ?", self.id, self.id).exists?
   end
 
   def can_be_deleted?

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -14,7 +14,7 @@ Spree::Address.class_eval do
 
   # can modify an address if it's not been used in an completed order
   def editable?
-    new_record? || Spree::Order.complete.where("bill_address_id = ? OR ship_address_id = ?", self.id, self.id).exists?
+    new_record? || !Spree::Order.complete.where("bill_address_id = ? OR ship_address_id = ?", self.id, self.id).exists?
   end
 
   def can_be_deleted?


### PR DESCRIPTION
This PR updates the `editable?` method on the `address_decorator.rb` class so that new addresses can be edited. The old conditions didn't allowed an address to be updated during checkout after the delivery step was reached since shipments where created there
