### PR TITLE
Delink addresses after an order is complete.

### DIFF
--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -35,18 +35,43 @@ describe Spree::Order do
     end
   end
 
-  describe 'default addresses should be references' do
+  describe 'address referencing' do
     let(:user) { create :user_with_addreses }
-    let(:order) { create :order, user: user, bill_address: nil, ship_address: nil }
+    let(:order) do
+      create(:order_with_line_items, user: user, bill_address: nil, ship_address: nil).tap do |order|
+        create :payment, amount: order.total, order: order, state: 'completed'
+      end
+    end
 
-    it 'should reference address instead of copy' do
+    before(:each) do
       expect( order.bill_address_id ).to be_nil
       expect( order.ship_address_id ).to be_nil
-
       order.assign_default_addresses!
+    end
 
+    it 'should initially reference address instead of copy' do
       expect( order.bill_address_id ).to eq user.bill_address_id
       expect( order.ship_address_id ).to eq user.ship_address_id
     end
+
+    it 'should clone addresses on complete' do
+      expect( order.state ).to eq 'cart'
+      expect( order.next ).to eq true until order.complete?
+      order.reload
+
+      # One complete the order address are no longer the user addresses
+      expect( order.bill_address_id ).not_to eq user.bill_address_id
+      expect( order.ship_address_id ).not_to eq user.ship_address_id
+
+      # The shipments should refer to the same object as the order does
+      for shipment in order.shipments
+        expect( shipment.address_id ).to eq order.ship_address_id
+      end
+
+      # Once complete the order addresses do not tie to the address book
+      expect( order.bill_address.user_id ).to be_nil
+      expect( order.ship_address.user_id ).to be_nil
+    end
   end
+
 end


### PR DESCRIPTION
This is the bulk of the work for satisifying https://trello.com/c/7GAFlQEB. Commit message contains the full details. There is one other minor issue. On nibley this gem is before `spree_digital`. `spree_digital` clears out the entire state machine removing the transition hook installed in this commit making this commit ineffective.

Once this commit is merged that will allow me to bump the version of the Gemfile. While doing that I will change the order on the Gemfile so this gem is loaded after `spree_digital`.
